### PR TITLE
Suggested typo & error catching fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.sconsign.dblite

--- a/SConstruct
+++ b/SConstruct
@@ -4,6 +4,7 @@ macports_env = Environment(
     LIBPATH=['/opt/local/lib'],
     )
 default_env = Environment()
+default_env = macports_env
 
 default_env.Program('ckcdda', ['ckcdda.c'],
                     CCFLAGS='-O2 -ggdb -std=c99 -Wall')

--- a/arverify.py
+++ b/arverify.py
@@ -53,12 +53,13 @@ class Track(object):
     """One track and its associated metadata/information"""
     exact_match_msg = 'Accurately ripped'
     possible_match_msg = 'Possibly accurately ripped'
+    not_accurate_msg = 'Definitely NOT accurately ripped'
     not_present_msg = 'Not present in database'
 
     not_accurate_fmt = '***Definitely not accurately ripped (%s)***'
     with_offset_fmt = ' with offset %i'
     _fmt = '%-20s: %08X'
-    total_fmt = 'total %i submissions'
+    total_fmt = 'total %i submission%s'
 
     def __init__(self, path):
         self.path = path

--- a/arverify.py
+++ b/arverify.py
@@ -63,6 +63,7 @@ class Track(object):
     def __init__(self, path):
         self.path = path
         self.num_samples = utils.get_num_samples(BIN, path)
+	print("track: %s, num_samples %d\n" % (path, self.num_samples))
         self.num_sectors = int(self.num_samples/588)
         if self.num_samples % 588 != 0:
             msg = "%s not from CD (%i samples)\n" % \
@@ -148,6 +149,8 @@ def process_arguments():
 
 def scan_files(tracks):
     sox_args = ['sox']+[t.path for t in tracks]+['-t', 'raw', '-']
+    print(', '.join(sox_args))
+    print("\n")
     entries_per_track = max([len(t.ar_entries) for t in tracks])
     ckcdda_args = [BIN['ckcdda'], entries_per_track]
 
@@ -165,6 +168,8 @@ def scan_files(tracks):
     tmp = TemporaryFile()
     PROCS.append(Popen(sox_args, stdout=PIPE))
     PROCS.append(Popen(ckcdda_args, stdin=PROCS[-1].stdout, stdout=tmp))
+    print(', '.join(ckcdda_args))
+    print("\n")
 
     p = PROCS[-1]
     while p.poll() is None:
@@ -366,6 +371,14 @@ def print_summary(tracks, verbose=False):
 def main(options):
     utils.check_dependencies(BIN, REQUIRED)
     tracks = [Track(path) for path in options.paths]
+    '''
+    from pprint import pprint
+    l = dir(tracks)
+    print("tracks::\n")
+    pprint(l)
+    print("\n::\n")
+    import pdb; pdb.set_trace()
+    '''
 
     cddb, id1, id2 = get_disc_ids(tracks, options.additional_sectors,
                                   options.data_track_len, options.verbose)

--- a/arverify.py
+++ b/arverify.py
@@ -150,8 +150,6 @@ def process_arguments():
 
 def scan_files(tracks):
     sox_args = ['sox']+[t.path for t in tracks]+['-t', 'raw', '-']
-    print(', '.join(sox_args))
-    print("\n")
     entries_per_track = max([len(t.ar_entries) for t in tracks])
     ckcdda_args = [BIN['ckcdda'], entries_per_track]
 
@@ -169,8 +167,6 @@ def scan_files(tracks):
     tmp = TemporaryFile()
     PROCS.append(Popen(sox_args, stdout=PIPE))
     PROCS.append(Popen(ckcdda_args, stdin=PROCS[-1].stdout, stdout=tmp))
-    print(', '.join(ckcdda_args))
-    print("\n")
 
     p = PROCS[-1]
     while p.poll() is None:
@@ -372,14 +368,6 @@ def print_summary(tracks, verbose=False):
 def main(options):
     utils.check_dependencies(BIN, REQUIRED)
     tracks = [Track(path) for path in options.paths]
-    '''
-    from pprint import pprint
-    l = dir(tracks)
-    print("tracks::\n")
-    pprint(l)
-    print("\n::\n")
-    import pdb; pdb.set_trace()
-    '''
 
     cddb, id1, id2 = get_disc_ids(tracks, options.additional_sectors,
                                   options.data_track_len, options.verbose)

--- a/utils.py
+++ b/utils.py
@@ -92,7 +92,6 @@ def check_dependencies(BIN, REQUIRED):
                 raise DependencyError("%s required\n" % dep)
         else:
             BIN[dep] = altvalue[0] if altvalue else value[0]
-	    # print("BIN[%s] = %s\n" % (dep, BIN[dep]))
 
 def add_common_arguments(parser, version):
     parser.add_argument("-v", "--verbose",
@@ -122,15 +121,12 @@ def finish_status(msg=''):
     sys.stderr.write('\n')
 
 def get_num_samples(BIN, path):
-    devnull = open(os.devnull, 'w')
     if fnmatch(path.lower(), '*.flac') and BIN['metaflac']:
         p = Popen([BIN['metaflac'], '--show-total-samples', path], stdout=PIPE)
         out, err = p.communicate()
         num_samples = int(out.strip())
     else:
 	try:
-	    #p = Popen([BIN['ffprobe'], '-show_streams', path], stdout=PIPE,
-	    #	      stderr=devnull)
 	    p = Popen([BIN['ffprobe'], '-show_streams', path], stdout=PIPE,
 		      stderr=PIPE)
 	    out, err = p.communicate()
@@ -146,8 +142,6 @@ def get_num_samples(BIN, path):
 				       (BIN['ffprobe'], '-show_streams',
 				        path, err))
         num_samples = int(round(dur*44100))
-
-    devnull.close()
 
     return num_samples
 


### PR DESCRIPTION
Hi, I've been using your code in my own custom flow of ripping about 500 cds using abcde, with your code to do the accuraterip portion.

The changes to utils.py were motivated because I hadn't installed ffmpeg, and 'avprobe' isn't supported (or isn't working) on the latest flavor of ubuntu.  I couldn't figure out why the code wasn't working, so had to insert a pile of debug statements until I figured it out (I'm getting up-to-speed on python).  Even when I had ffmpeg installed, I ran into problems when my LD_LIBRARY_PATH wasn't right.

Thus my change of the open of 'ffprobe' in util.py to use try/except, and my checking of the return status if we don't see a duration string in the output.

I also noticed in arverify.py that the not_accurate_msg wasn't defined, and a small typo with total_fmt.

Thanks for making your code publicly available -- using it makes my process a lot easier than running Windows and using EAC!

tim
